### PR TITLE
Add rank metadata to dependency traces

### DIFF
--- a/python/triton_dist/mega_triton_kernel/models/model_builder.py
+++ b/python/triton_dist/mega_triton_kernel/models/model_builder.py
@@ -599,6 +599,8 @@ class ModelBuilder:
                 wq_tensor=self.wq_tensor,
                 num_tasks_tensor=self.num_tasks_tensor,
                 scheduled_tasks=self._scheduled_tasks,
+                rank=self.rank,
+                world_size=self.world_size,
                 base_dir=dependency_trace_base_dir,
             )
         else:


### PR DESCRIPTION
## Summary
- include rank and world size metadata when exporting mega-kernel dependency traces
- persist rank information for tasks and dependencies in the profiler trace service so merged graphs can span ranks

## Testing
- python -m compileall python/triton_dist/tools/profiler/dependency_trace.py python/triton_dist/mega_triton_kernel/models/model_builder.py python/triton_dist/tools/profiler/critical_path_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d69c699c7c832b9f80ed9c4bf4d0fd